### PR TITLE
Update config_ui_qt.py

### DIFF
--- a/autoortho/config_ui_qt.py
+++ b/autoortho/config_ui_qt.py
@@ -474,10 +474,10 @@ class ConfigUI(QMainWindow):
 
         # Scenery path
         scenery_layout = QHBoxLayout()
-        scenery_label = QLabel("Custom Scenery folder:")
+        scenery_label = QLabel("Scenery Install Folder:") # Changed from "Custom Scenery folder:"
         scenery_label.setToolTip(
             "Directory where AutoOrtho scenery will be installed.\n"
-            "This should be a your X-Plane Custom Scenery folder."
+            "This should be a your X-Plane Custom Scenery folder or another location."
         )
         scenery_layout.addWidget(scenery_label)
         self.scenery_path_edit = QLineEdit(self.cfg.paths.scenery_path)
@@ -1386,6 +1386,19 @@ class ConfigUI(QMainWindow):
 
     def on_save(self):
         """Handle Save button click"""
+        # Check if the directory exists
+        scenery_path = self.scenery_path_edit.text()
+        if not os.path.isdir(scenery_path):
+            reply = QMessageBox.question(
+                self,
+                'Create Folder?',
+                f"The directory '{scenery_path}' does not exist. Do you want to create it?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.Yes
+            )
+            if reply == QMessageBox.StandardButton.No:
+                self.update_status_bar("Save cancelled.")
+                return
         # Check if program is already running
         if self.running:
             reply = QMessageBox.question(
@@ -1403,6 +1416,7 @@ class ConfigUI(QMainWindow):
         
         self.save_config()
         self.cfg.load()
+        self.refresh_scenery_list()
         
         # Update bandwidth limiter with new settings
         try:


### PR DESCRIPTION
### PR Description

**Subject: `fix: Refresh scenery tab and improve UI clarity`**

This pull request addresses several UI and usability issues reported in #25 and #26, improving the overall user experience.

**Key Changes:**

* **Scenery Tab Auto-Refresh:** The Scenery tab now automatically updates when the configuration is saved, immediately reflecting changes to the scenery install folder.
* **Improved UI Labeling:** Renamed the ambiguous "Custom Scenery folder" to the more descriptive "Scenery Install Folder" to avoid confusion.
* **Folder Creation Confirmation:** A confirmation dialog now appears if the specified "Scenery Install Folder" does not exist, preventing accidental folder creation from typos.

These changes make the configuration process more intuitive and robust.

Closes #25, Closes #26