### PR TITLE
Suggestion: Showing downloaded tiles in a GUI window.

### DIFF
--- a/autoortho/aoconfig.py
+++ b/autoortho/aoconfig.py
@@ -4,7 +4,8 @@ import os
 import ast
 import pprint
 import configparser
-import platform
+from types import SimpleNamespace
+from utils.constants import system_type
 
 import logging
 log = logging.getLogger(__name__)
@@ -82,8 +83,8 @@ fetch_threads = 32
 simheaven_compat = False
 # Using custom generated Ortho4XP tiles along with AutoOrtho.
 using_custom_tiles = False
-# Shows the downloaded tiles info before loading into a flight.
-show_downloaded_tiles = False
+# Shows the loaded tiles info, such as filename and size, in a simple GUI window.
+show_loaded_tiles = False
 
 [pydds]
 # ISPC or STB for dds file compression
@@ -109,8 +110,6 @@ xplane_udp_port = 49000
 # Max size of the image disk cache in GB. Minimum of 10GB
 file_cache_size = 30
 # Max size of memory cache in GB. Minimum of 2GB.
-cache_mem_limit = 4
-# Max size of memory cache in GB. Minimmum of 2GB.
 cache_mem_limit = 4
 # Auto clean cache on AutoOrtho exit
 auto_clean_cache = False
@@ -167,7 +166,7 @@ prefer_winfsp = True
             sceneries = os.listdir(self.ao_scenery_path)
             log.info(f"Found sceneries: {sceneries}")
         
-        if platform.system() == "Darwin":
+        if system_type == "darwin":
             try:
                 if ".DS_Store" in sceneries:
                     sceneries.remove(".DS_Store")

--- a/autoortho/aoconfig.py
+++ b/autoortho/aoconfig.py
@@ -82,6 +82,8 @@ fetch_threads = 32
 simheaven_compat = False
 # Using custom generated Ortho4XP tiles along with AutoOrtho.
 using_custom_tiles = False
+# Shows the downloaded tiles info before loading into a flight.
+show_downloaded_tiles = False
 
 [pydds]
 # ISPC or STB for dds file compression

--- a/autoortho/autoortho.py
+++ b/autoortho/autoortho.py
@@ -39,7 +39,6 @@ class MountError(Exception):
 class AutoOrthoError(Exception):
     pass
 
-
 @contextmanager
 def setupmount(mountpoint, systemtype):
     mountpoint = os.path.expanduser(mountpoint)
@@ -402,6 +401,7 @@ def main():
     args = parser.parse_args()
 
     CFG = aoconfig.CFG
+
     if args.configure or (CFG.general.showconfig and not args.headless):
         # Show cfgui at start
         run_headless = False
@@ -445,6 +445,20 @@ def main():
             app = QApplication(sys.argv)
             cfgui = AOMountUI(CFG)
             cfgui.show()
+
+            # Show Downloaded Tiles - Call
+
+            if getattr(CFG.autoortho, "show_downloaded_tiles", False):
+                from tile_printer import start_tile_printer
+                start_tile_printer()
+                try:
+                    from tile_printer import send_tile_msg
+                    send_tile_msg("MINIMIZE_WINDOW")
+                except Exception:
+                    pass
+
+            # End of Show Downloaded Tiles - Call
+            
             app.exec()
         else:
             cfgui = AOMountUI(CFG)

--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -294,6 +294,18 @@ class Chunk(object):
                     log.debug(f"Cache file already exists for {self}, skipping save (race) on attempt {attempt}")
                     return
                 os.replace(temp_filename, self.cache_path)
+
+                # Show Downloaded Tiles - Message
+
+                if os.path.abspath(self.cache_dir) == os.path.abspath(CFG.paths.cache_dir):
+                    from tile_printer import send_tile_msg
+                    tile_filename = os.path.basename(self.cache_path)
+                    size_mb = len(data) / (1024 * 1024)
+                    msg = f"{tile_filename} ({size_mb:.2f} MB)"
+                    send_tile_msg(msg)
+
+                # End of Show Downloaded Tiles - Message
+
                 return
             except FileExistsError:
                 try:

--- a/autoortho/tile_printer.py
+++ b/autoortho/tile_printer.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import socket
+import subprocess
+import threading
+import queue
+
+tile_printer_proc = None
+TCP_PORT = 50505
+
+_msg_queue = queue.Queue()
+_sender_thread = None
+
+def _sender():
+    sock = None
+    while True:
+        msg = _msg_queue.get()
+        if msg is None:
+            if sock:
+                sock.close()
+            break
+        while True:
+            try:
+                if sock is None:
+                    sock = socket.create_connection(('127.0.0.1', TCP_PORT), timeout=2)
+                sock.sendall((msg + "\n").encode())
+                break
+            except Exception:
+                if sock:
+                    try:
+                        sock.close()
+                    except Exception:
+                        pass
+                    sock = None
+                import time
+                time.sleep(0.5)  # Wait before retrying
+
+def send_tile_msg(msg):
+    try:
+        _msg_queue.put_nowait(msg)
+    except Exception:
+        pass
+
+def start_tile_printer():
+    global tile_printer_proc, _sender_thread
+    if tile_printer_proc is None:
+        script_path = os.path.join(os.path.dirname(__file__), "tile_printer_gui.py")
+        tile_printer_proc = subprocess.Popen([sys.executable, script_path])
+    if _sender_thread is None:
+        _sender_thread = threading.Thread(target=_sender, daemon=True)
+        _sender_thread.start()
+
+def stop_tile_printer():
+    global tile_printer_proc, _sender_thread
+    if tile_printer_proc:
+        try:
+            tile_printer_proc.terminate()
+            tile_printer_proc.wait(timeout=2)
+        except Exception:
+            pass
+        tile_printer_proc = None
+    if _sender_thread:
+        _msg_queue.put(None)
+        _sender_thread = None

--- a/autoortho/tile_printer.py
+++ b/autoortho/tile_printer.py
@@ -33,7 +33,7 @@ def _sender():
                         pass
                     sock = None
                 import time
-                time.sleep(0.5)  # Wait before retrying
+                time.sleep(0.5)
 
 def send_tile_msg(msg):
     try:

--- a/autoortho/tile_printer_gui.py
+++ b/autoortho/tile_printer_gui.py
@@ -1,0 +1,94 @@
+import sys
+import re
+import socket
+import platform
+import threading
+import utils.resources_rc
+from PySide6.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QLabel, QTextEdit, QPushButton
+)
+from PySide6.QtCore import Qt, Signal, QObject
+from PySide6.QtGui import QTextCursor, QIcon
+
+TCP_PORT = 50505
+
+class Communicate(QObject):
+    new_msg = Signal(str)
+
+class TilePrinterGUI(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Tiles Download Info")
+        self.resize(320, 160)
+
+        self.system = platform.system().lower()
+        if self.system == 'windows':
+            icon_path = ":/imgs/ao-icon.ico"
+        else:
+            icon_path = ":/imgs/ao-icon.png"
+        self.setWindowIcon(QIcon(icon_path))
+
+        self.total_mb = 0.0
+
+        layout = QVBoxLayout()
+        self.total_label = QLabel("Total Downloaded Size: 0.00 MB")
+        self.total_label.setAlignment(Qt.AlignLeft)
+        layout.addWidget(self.total_label)
+
+        self.clear_button = QPushButton("Clear")
+        self.clear_button.clicked.connect(self.clear_all)
+        layout.addWidget(self.clear_button)
+
+        self.text_area = QTextEdit()
+        self.text_area.setReadOnly(True)
+        layout.addWidget(self.text_area)
+
+        self.setLayout(layout)
+
+        # Signal for thread-safe GUI update
+        self.comm = Communicate()
+        self.comm.new_msg.connect(self.handle_msg)
+
+        # Start TCP server in a thread
+        self.server_thread = threading.Thread(target=self.tcp_server, daemon=True)
+        self.server_thread.start()
+
+    def clear_all(self):
+        self.text_area.clear()
+        self.total_mb = 0.0
+        self.total_label.setText("Total Downloaded Size: 0.00 MB")
+
+    def handle_msg(self, line):
+        if line == "MINIMIZE_WINDOW":
+            self.showMinimized()
+            return
+        self.text_area.append(line.rstrip())
+        match = re.search(r'\(([\d.]+) MB\)', line)
+        if match:
+            self.total_mb += float(match.group(1))
+            self.total_label.setText(f"Total Downloaded Size: {self.total_mb:.2f} MB")
+        self.text_area.moveCursor(QTextCursor.End)
+
+    def tcp_server(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(('127.0.0.1', TCP_PORT))
+            s.listen(1)
+            while True:
+                conn, _ = s.accept()
+                with conn:
+                    try:
+                        while True:
+                            data = conn.recv(1024)
+                            if not data:
+                                break
+                            for line in data.decode(errors="ignore").splitlines():
+                                self.comm.new_msg.emit(line)
+                    except ConnectionResetError:
+                        pass
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = TilePrinterGUI()
+    window.show()
+    sys.exit(app.exec())

--- a/autoortho/tile_printer_gui.py
+++ b/autoortho/tile_printer_gui.py
@@ -5,7 +5,7 @@ import platform
 import threading
 import utils.resources_rc
 from PySide6.QtWidgets import (
-    QApplication, QWidget, QVBoxLayout, QLabel, QTextEdit, QPushButton
+    QApplication, QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QLabel, QTextEdit, QPushButton
 )
 from PySide6.QtCore import Qt, Signal, QObject
 from PySide6.QtGui import QTextCursor, QIcon
@@ -18,8 +18,8 @@ class Communicate(QObject):
 class TilePrinterGUI(QWidget):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("Tiles Download Info")
-        self.resize(320, 160)
+        self.setWindowTitle("Loaded Tiles Info")
+        self.resize(420, 240)
 
         self.system = platform.system().lower()
         if self.system == 'windows':
@@ -28,16 +28,57 @@ class TilePrinterGUI(QWidget):
             icon_path = ":/imgs/ao-icon.png"
         self.setWindowIcon(QIcon(icon_path))
 
+        self.downloaded_size = 0.0
+        self.downloaded_count = 0
+
+        self.retrieved_size = 0.0
+        self.retrieved_count = 0
+
         self.total_mb = 0.0
+        self.total_count = 0
+        self.total_error = 0
+
+        self.paused = False
+        self.paused_queue = []
+
+        label_grid = QGridLayout()
+        self.total_downloaded_count_label = QLabel("Downloaded Tiles: 0")
+        self.total_downloaded_count_label.setAlignment(Qt.AlignLeft)
+        label_grid.addWidget(self.total_downloaded_count_label, 0, 0)
+
+        self.total_downloaded_size_label = QLabel("Downloaded Tiles Size: 0 MB")
+        self.total_downloaded_size_label.setAlignment(Qt.AlignRight)
+        label_grid.addWidget(self.total_downloaded_size_label, 0, 1)
+
+        self.total_retrieved_count_label = QLabel("Retrieved Tiles: 0")
+        self.total_retrieved_count_label.setAlignment(Qt.AlignLeft)
+        label_grid.addWidget(self.total_retrieved_count_label, 1, 0)
+
+        self.total_retrieved_size_label = QLabel("Retrieved Tiles Size: 0 MB")
+        self.total_retrieved_size_label.setAlignment(Qt.AlignRight)
+        label_grid.addWidget(self.total_retrieved_size_label, 1, 1)
+
+        self.total_error_label = QLabel("Errors Found: 0 Error(s)")
+        self.total_error_label.setAlignment(Qt.AlignLeft)
+        label_grid.addWidget(self.total_error_label, 2, 0)
+
+        self.total_tiles_label = QLabel("Total Tiles Count/Size: 0/0 MB")
+        self.total_tiles_label.setAlignment(Qt.AlignRight)
+        label_grid.addWidget(self.total_tiles_label, 2, 1)
 
         layout = QVBoxLayout()
-        self.total_label = QLabel("Total Downloaded Size: 0.00 MB")
-        self.total_label.setAlignment(Qt.AlignLeft)
-        layout.addWidget(self.total_label)
+        layout.addLayout(label_grid)
 
+        button_layout = QHBoxLayout()
         self.clear_button = QPushButton("Clear")
         self.clear_button.clicked.connect(self.clear_all)
-        layout.addWidget(self.clear_button)
+        button_layout.addWidget(self.clear_button)
+
+        self.pause_button = QPushButton("Pause")
+        self.pause_button.clicked.connect(self.toggle_pause)
+        button_layout.addWidget(self.pause_button)
+
+        layout.addLayout(button_layout)
 
         self.text_area = QTextEdit()
         self.text_area.setReadOnly(True)
@@ -45,28 +86,65 @@ class TilePrinterGUI(QWidget):
 
         self.setLayout(layout)
 
-        # Signal for thread-safe GUI update
         self.comm = Communicate()
         self.comm.new_msg.connect(self.handle_msg)
 
-        # Start TCP server in a thread
         self.server_thread = threading.Thread(target=self.tcp_server, daemon=True)
         self.server_thread.start()
 
     def clear_all(self):
         self.text_area.clear()
+        self.downloaded_size = 0.0
+        self.downloaded_count = 0
+        self.retrieved_size = 0.0
+        self.retrieved_count = 0
         self.total_mb = 0.0
-        self.total_label.setText("Total Downloaded Size: 0.00 MB")
+        self.total_count = 0
+        self.total_error = 0
+
+        self.total_downloaded_count_label.setText("Downloaded Tiles: 0")
+        self.total_downloaded_size_label.setText("Downloaded Tiles Size: 0 MB")
+        self.total_retrieved_count_label.setText("Retrieved Tiles: 0")
+        self.total_retrieved_size_label.setText("Retrieved Tiles Size: 0 MB")
+        self.total_error_label.setText("Errors Found: 0 Error(s)")
+        self.total_tiles_label.setText("Total Tiles Count/Size: 0/0 MB")
+
+    def toggle_pause(self):
+        self.paused = not self.paused
+        if self.paused:
+            self.pause_button.setText("Resume")
+            self.setWindowTitle("Loaded Tiles Info (Paused)")
+        else:
+            self.pause_button.setText("Pause")
+            self.setWindowTitle("Loaded Tiles Info")
+            for msg in self.paused_queue:
+                self.handle_msg(msg)
+            self.paused_queue.clear()
 
     def handle_msg(self, line):
-        if line == "MINIMIZE_WINDOW":
-            self.showMinimized()
+        if self.paused:
+            self.paused_queue.append(line)
             return
         self.text_area.append(line.rstrip())
         match = re.search(r'\(([\d.]+) MB\)', line)
-        if match:
-            self.total_mb += float(match.group(1))
-            self.total_label.setText(f"Total Downloaded Size: {self.total_mb:.2f} MB")
+        if "Error" in line:
+            self.total_error+=1
+            self.total_error_label.setText(f"Errors Found: {self.total_error} Error(s)")
+        else:
+            if match:
+                if "Downloaded" in line:
+                    self.downloaded_count += 1
+                    self.downloaded_size += float(match.group(1))
+                    self.total_downloaded_count_label.setText(f"Downloaded Tiles: {self.downloaded_count}")
+                    self.total_downloaded_size_label.setText(f"Downloaded Tiles Size: {self.downloaded_size:.2f} MB")
+                elif "Retrieved" in line:
+                    self.retrieved_count += 1
+                    self.retrieved_size += float(match.group(1))
+                    self.total_retrieved_count_label.setText(f"Retrieved Tiles: {self.retrieved_count}")
+                    self.total_retrieved_size_label.setText(f"Retrieved Tiles Size: {self.retrieved_size:.2f} MB")
+                self.total_count = self.downloaded_count + self.retrieved_count
+                self.total_mb = self.downloaded_size + self.retrieved_size
+                self.total_tiles_label.setText(f"Total Tiles Count/Size: {self.total_count}/{self.total_mb:.2f} MB")
         self.text_area.moveCursor(QTextCursor.End)
 
     def tcp_server(self):


### PR DESCRIPTION
Before loading into a flight, in the 'Reading new scenery files' loading screen, I wanted to know if AutoOrtho was doing anything, especially if the tiles were being downloaded, since it takes a short while until its done loading.

So, I just made a simple, experimental option called 'Show downloaded tiles', that just creates a second window/subprocess and shows a list of downloaded tiles and their size, as well as the total downloaded size (all in MB), and a clear button to reset everything in that window.

Currently, I don't know how to show the window when X-Plane goes into a loading screen and minimize when X-Plane is done loading/flight starts.

This does not affect functionality, but IMO enhances user experience. My way of implementation is very scuffed, and it is my first time doing something like this. If possible, do try to look into this, thanks!