### PR TITLE
Add control to change the missing tile color

### DIFF
--- a/autoortho/aoconfig.py
+++ b/autoortho/aoconfig.py
@@ -92,6 +92,8 @@ fetch_threads = 32
 simheaven_compat = False
 # Using custom generated Ortho4XP tiles along with AutoOrtho.
 using_custom_tiles = False
+# Color used for missing textures.
+missing_color = [66, 77, 55]
 
 [pydds]
 # ISPC or STB for dds file compression

--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -903,7 +903,15 @@ class Tile(object):
         
         log.debug(f"GET_IMG: Create new image: Zoom: {zoom} | {(img_width, img_height)}")
         
-        new_im = AoImage.new('RGBA', (img_width, img_height), (66,77,55))
+        new_im = AoImage.new(
+            "RGBA",
+            (img_width, img_height),
+            (
+                CFG.autoortho.missing_color[0],
+                CFG.autoortho.missing_color[1],
+                CFG.autoortho.missing_color[2],
+            ),
+        )
 
         log.debug(f"GET_IMG: Will use image {new_im}")
 


### PR DESCRIPTION
This control allows a user to set the missing tile color to any color they want.

The current default missing tile color is a dark gray, which makes it hard to see, which is fairly acceptable during normal operation since it makes missing tiles less noticable.  But if one is tuning the maxwait setting, they might want to see more easily any missing tiles. This can help them distinguish between actual missing tiles and "popping" caused by differences in textures between ZLs.