### PR TITLE
gui: Don't let scrolling move sliders

### DIFF
--- a/autoortho/config_ui_qt.py
+++ b/autoortho/config_ui_qt.py
@@ -30,7 +30,7 @@ from PySide6.QtCore import (
     Qt, QThread, Signal, QTimer, QSize
 )
 from PySide6.QtGui import (
-    QPixmap, QIcon, QColor
+    QPixmap, QIcon, QColor, QWheelEvent
 )
 
 import downloader
@@ -246,6 +246,8 @@ class ModernSlider(QSlider):
                 border-radius: 3px;
             }
         """)
+    def wheelEvent(self, event: QWheelEvent):
+        event.ignore()
 
 
 class ModernSpinBox(QSpinBox):


### PR DESCRIPTION
Using a mouse scroll wheel to scroll the options in the Advanced Settings tab can cause unwanted slider movements.

Fix by ignoring QWheelEvents in ModernSlider.