### PR TITLE
Fix downloader noclean option

### DIFF
--- a/autoortho/config_ui_qt.py
+++ b/autoortho/config_ui_qt.py
@@ -62,7 +62,8 @@ class SceneryDownloadWorker(QThread):
                 self.progress.emit(self.region_id, progress_data)
 
             success = region.install_release(
-                progress_callback=progress_callback
+                progress_callback=progress_callback,
+                noclean=self.dl_manager.noclean
             )
             self.finished.emit(self.region_id, success)
 
@@ -2384,6 +2385,7 @@ class ConfigUI(QMainWindow):
 
             # Scenery settings
             self.cfg.scenery.noclean = self.noclean_check.isChecked()
+            self.dl.noclean = self.cfg.scenery.noclean
 
             # FUSE settings
             self.cfg.fuse.threading = self.threading_check.isChecked()

--- a/autoortho/downloader.py
+++ b/autoortho/downloader.py
@@ -602,7 +602,7 @@ class Release(object):
         self.downloaded = True
         return True
 
-    def install(self, progress_callback=None):
+    def install(self, progress_callback=None, noclean=False):
         if self.installed:
             log.info(f"Already installed {self.name}")
             return True
@@ -621,7 +621,8 @@ class Release(object):
             return False
         self.save()
         self.installed = True
-        self.cleanup()
+        if not noclean:
+            self.cleanup()
         return True
 
     def verify_and_install_all(self, progress_callback=None):
@@ -779,7 +780,7 @@ class Region(object):
         log.debug(f"SORTED: {releases}")
         return releases[0]
 
-    def install_release(self, ver=None, progress_callback=None):
+    def install_release(self, ver=None, progress_callback=None, noclean=False):
 
         if ver is None:
             rel = self.get_latest_release()
@@ -799,7 +800,7 @@ class Region(object):
             log.error(f"Failed to download release {rel}")
             return False
 
-        if not rel.install(progress_callback=progress_callback):
+        if not rel.install(progress_callback=progress_callback, noclean=noclean):
             log.error(f"Failed to install release {rel}")
             return False
 


### PR DESCRIPTION
The noclean option seems to have gotten lost with the recent changes. It was being ignored by the scenery installer causing the installer to always cleanup the downloaded zip files after an install.

Propagate the noclean flag in the SceneryDownloadWorker so that the cleanup step can be skipped if indicated.

Also update the noclean state of the persistent dl object when the user changes the checkbox in the GUI and saves the settings.