### PR TITLE
cleanup: Remove unneeded XX_ from cache temp fname

### DIFF
--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -330,7 +330,7 @@ class Chunk(object):
             pass
 
         # Unique temp filename per writer to avoid collisions between threads/tiles
-        temp_filename = os.path.join(self.cache_dir, f"XX_{self.chunk_id}_{uuid.uuid4().hex}.tmp")
+        temp_filename = os.path.join(self.cache_dir, f"{self.chunk_id}_{uuid.uuid4().hex}.tmp")
 
         # Write data to the unique temp file first
         try:


### PR DESCRIPTION
I meant to make this better before this fork, but now that the cache temp filename is randomized with uuid4, there's no need for the XX_ prefix.  Removing to avoid future wondering about why it is there.