### PR TITLE
fuse: Stop throwing exceptions on flush()

### DIFF
--- a/autoortho/autoortho_fuse.py
+++ b/autoortho/autoortho_fuse.py
@@ -528,6 +528,7 @@ class AutoOrtho(Operations):
             except OSError as e:
                 raise FuseOSError(e.errno)
 
+    # X-Plane never writes to files in the FUSE mount
     def _write(self, path, buf, offset, fh):
         os.lseek(fh, offset, os.SEEK_SET)
         return os.write(fh, buf)
@@ -538,7 +539,8 @@ class AutoOrtho(Operations):
         with open(full_path, 'r+') as f:
             f.truncate(length)
 
-    def flush(self, path, fh):
+    # X-Plane never writes to files in the FUSE mount
+    def _flush(self, path, fh):
         # No-op for virtual DDS files; fsync real files.
         if self.dds_re.match(path):
             return 0
@@ -572,7 +574,8 @@ class AutoOrtho(Operations):
         finally:
             self.fh_locks.pop(fh, None)
 
-    def fsync(self, path, fdatasync, fh):
+    # X-Plane never writes to files in the FUSE mount
+    def _fsync(self, path, fdatasync, fh):
         log.debug(f"FSYNC: {path}")
         return self.flush(path, fh)
 


### PR DESCRIPTION
X-Plane doesn't write to any the files in the scenery fuse mounts, which means that this fuse module doesn't need to define flush(), sync(), and write(). (write was already not defined before this commit)

Rename the flush() and sync() functions so that fuse does not intercept them.

This fixes a problem with flush() where flush() was calling the OS flush() function with a bad handle.  The bad handle caused an exception and triggered exception processing, which was harmless, but logged the error in the (debug) log and used up some time in the XP rendering thread.  The call to flush() was probably triggered by XP closing .ter and .png files found in the scenery.  It isn't clear why flush() was being called when the files should have been opened only for reading, making flushing them unnecessary.

This change saves a few dozen microseconds for each file in the scenery that XP opens, which isn't much.  But there are a lot of these files and it adds up.