### PR TITLE
Add Ubuntu 22.04 build

### DIFF
--- a/.github/workflows/ReleaseSharedWorkflow2.yml
+++ b/.github/workflows/ReleaseSharedWorkflow2.yml
@@ -38,7 +38,10 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
 
     env:
       VERNAME: ${{ inputs.version }} 
@@ -63,7 +66,7 @@ jobs:
     - name: Save artifact
       uses: actions/upload-artifact@v4
       with:
-        name: linbin
+        name: linbin_${{ matrix.os }}
         path: autoortho_lin_*.bin
 
     - name: Release

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -29,7 +29,10 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
 
@@ -56,7 +59,7 @@ jobs:
     - name: Save artifact
       uses: actions/upload-artifact@v4
       with:
-        name: linbin
+        name: linbin_${{ matrix.os }}
         path: autoortho_linux_*.tar.gz
 
     - name: Release
@@ -66,7 +69,6 @@ jobs:
         files: autoortho_linux_*.tar.gz
         tag_name: ${{ inputs.relname }}
         prerelease: ${{ inputs.prerelease }}
-        make_latest: ${{ inputs.make_latest }}
         body: ${{ inputs.releasebody }}
 
 
@@ -113,7 +115,6 @@ jobs:
         files: AutoOrtho_mac_*.zip
         tag_name: ${{ inputs.relname }}
         prerelease: ${{ inputs.prerelease }}
-        make_latest: ${{ inputs.make_latest }}
         body: ${{ inputs.releasebody }}
 
 
@@ -165,5 +166,4 @@ jobs:
           autoortho_win_*.zip
         tag_name: ${{ inputs.relname }}
         prerelease: ${{ inputs.prerelease }}
-        make_latest: ${{ inputs.make_latest }}
         body: ${{ inputs.releasebody }}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ZIP?=zip
 VERSION?=0.0.0
 # Sanitize VERSION for use in filenames (replace any non-safe char with '-')
 SAFE_VERSION:=$(shell echo "$(VERSION)" | sed -e 's/[^A-Za-z0-9._-]/-/g')
+CODE_NAME:=$(shell grep UBUNTU_CODENAME /etc/os-release | cut -d= -f2)
 .PHONY: mac_app
 SHELL := /bin/bash
 .ONESHELL:
@@ -12,13 +13,13 @@ autoortho.pyz:
 	python3 -m pip install -U -r ./build/autoortho/build-reqs.txt --target ./build/autoortho
 	cd build && python3 -m zipapp -p "/usr/bin/env python3" autoortho
 
-lin_bin: autoortho_lin_$(SAFE_VERSION).bin
-autoortho_lin_$(SAFE_VERSION).bin: autoortho/*.py
-	docker run --rm -v `pwd`:/code ubuntu:noble /bin/bash -c "cd /code; ./buildreqs.sh; . .venv/bin/activate; time make bin VERSION=$(VERSION)"
+lin_bin: autoortho_lin_$(SAFE_VERSION)_${CODE_NAME}.bin
+autoortho_lin_$(SAFE_VERSION)_${CODE_NAME}.bin: autoortho/*.py
+	docker run --rm -v `pwd`:/code ubuntu:${CODE_NAME} /bin/bash -c "cd /code; ./buildreqs.sh; . .venv/bin/activate; time make bin VERSION=$(VERSION)"
 	mv autoortho_lin.bin $@
 
-lin_tar: autoortho_linux_$(SAFE_VERSION).tar.gz
-autoortho_linux_$(SAFE_VERSION).tar.gz: autoortho_lin_$(SAFE_VERSION).bin
+lin_tar: autoortho_linux_$(SAFE_VERSION)_${CODE_NAME}.tar.gz
+autoortho_linux_$(SAFE_VERSION)_${CODE_NAME}.tar.gz: autoortho_lin_$(SAFE_VERSION)_${CODE_NAME}.bin
 	chmod a+x $<
 	tar -czf $@ $<
 

--- a/buildreqs.sh
+++ b/buildreqs.sh
@@ -15,6 +15,22 @@ apt-get install -y make curl patchelf python3-pip python3-venv python3-tk zlib1g
     libglib2.0-0 libx11-6 libxcb1 libxkbcommon0 libdbus-1-3 libfontconfig1 libfreetype6 \
     libgl1 libegl1
 
+if python3 -c 'import sys; exit(0) if sys.version_info.minor < 12 else exit(1)'; then
+    echo "Installing Python 3.12 with pyenv..."
+    apt-get install -y git libssl-dev \
+        libbz2-dev libreadline-dev libsqlite3-dev \
+        libncursesw5-dev tk-dev libxml2-dev \
+        libxmlsec1-dev libffi-dev liblzma-dev
+    curl https://pyenv.run | bash
+    export PYENV_ROOT="$HOME/.pyenv"
+    [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init - bash)"
+    pyenv install 3.12.3
+    pyenv global 3.12.3
+fi
+echo "Using Python version: "
+python3 --version
+
 # Create and prepare an isolated virtual environment to avoid PEP 668 restrictions
 echo "Creating virtual environment..."
 python3 -m venv .venv


### PR DESCRIPTION
Fixes: #146

- Add Linux job matrix to Actions to run with two different distros
- Add Ubuntu code names to artifact file names to keep them separate
- If Python is pre-3.12 in the distro, install and use Python 3.12
- Remove obsolete make_latest parameter to gh release action