### PR TITLE
build: Create linker map file for Windows build

### DIFF
--- a/.github/workflows/ReleaseSharedWorkflow2.yml
+++ b/.github/workflows/ReleaseSharedWorkflow2.yml
@@ -130,6 +130,7 @@ jobs:
 
     env:
       VERNAME: ${{ inputs.version }} 
+      LDFLAGS: -Wl,-Map=autoortho.map # Assuming gcc (mingw64 compiler)
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -125,6 +125,7 @@ jobs:
 
     env:
       VERNAME: ${{ inputs.version }} 
+      LDFLAGS: -Wl,-Map=autoortho.map # Assuming gcc (mingw64 compiler)
 
     steps:
     - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ AutoOrtho_win_$(SAFE_VERSION).exe: __main__.dist
 win_zip: autoortho_win_$(SAFE_VERSION).zip
 autoortho_win_$(SAFE_VERSION).zip: __main__.dist
 	mv __main__.dist autoortho_release
+	if [ -f __main__.build/autoortho.map ]; then cp __main__.build/autoortho.map autoortho_release; fi
 	$(ZIP) $@ autoortho_release
 
 testperf:


### PR DESCRIPTION
The map file can be useful for locating what module a fault/crash occurred in when given an offset (as in a Windows Event report).

The file is placed in the winbin artifact.