### PR TITLE
Add Ubuntu 22.04 build

### DIFF
--- a/.github/workflows/ReleaseSharedWorkflow2.yml
+++ b/.github/workflows/ReleaseSharedWorkflow2.yml
@@ -38,7 +38,10 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
 
     env:
       VERNAME: ${{ inputs.version }} 
@@ -63,14 +66,14 @@ jobs:
     - name: Save artifact
       uses: actions/upload-artifact@v4
       with:
-        name: linbin
-        path: autoortho_lin_*.bin
+        name: linbin_${{ matrix.os }}
+        path: autoortho_linux_*
 
     - name: Release
       if: ${{ inputs.relname != '' }}
       uses: softprops/action-gh-release@v1
       with:
-        files: autoortho_lin_*.bin
+        files: autoortho_linux_*
         tag_name: ${{ inputs.relname }}
         prerelease: ${{ inputs.prerelease }}
 

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -29,7 +29,10 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
 
@@ -56,7 +59,7 @@ jobs:
     - name: Save artifact
       uses: actions/upload-artifact@v4
       with:
-        name: linbin
+        name: linbin_${{ matrix.os }}
         path: autoortho_linux_*.tar.gz
 
     - name: Release

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ZIP?=zip
 VERSION?=0.0.0
 # Sanitize VERSION for use in filenames (replace any non-safe char with '-')
 SAFE_VERSION:=$(shell echo "$(VERSION)" | sed -e 's/[^A-Za-z0-9._-]/-/g')
+CODE_NAME:=$(shell grep UBUNTU_CODENAME /etc/os-release | cut -d= -f2)
 .PHONY: mac_app clean
 SHELL := /bin/bash
 .ONESHELL:
@@ -15,10 +16,10 @@ autoortho/.version:
 # =============================================================================
 # Linux Build (PyInstaller)
 # =============================================================================
-lin_bin: autoortho_linux_$(SAFE_VERSION)
-autoortho_linux_$(SAFE_VERSION): autoortho/*.py autoortho/.version
+lin_bin: autoortho_linux_$(SAFE_VERSION)_$(CODE_NAME)
+autoortho_linux_$(SAFE_VERSION)_$(CODE_NAME): autoortho/*.py autoortho/.version
 	# Build inside Docker and rename output folder (all as root to avoid permission issues)
-	docker run --rm -v `pwd`:/code ubuntu:latest /bin/bash -c "\
+	docker run --rm -v `pwd`:/code ubuntu:$(CODE_NAME) /bin/bash -c "\
 		cd /code && \
 		./buildreqs.sh && \
 		. .venv/bin/activate && \
@@ -27,10 +28,10 @@ autoortho_linux_$(SAFE_VERSION): autoortho/*.py autoortho/.version
 		mv dist/autoortho autoortho_linux_$(SAFE_VERSION) && \
 		chmod -R a+rw autoortho_linux_$(SAFE_VERSION)"
 
-lin_tar: autoortho_linux_$(SAFE_VERSION).tar.gz
-autoortho_linux_$(SAFE_VERSION).tar.gz: autoortho_linux_$(SAFE_VERSION)
+lin_tar: autoortho_linux_$(SAFE_VERSION)_$(CODE_NAME).tar.gz
+autoortho_linux_$(SAFE_VERSION)_$(CODE_NAME).tar.gz: autoortho_linux_$(SAFE_VERSION)_$(CODE_NAME)
 	# Package entire folder (includes ao_files/ with all bundled dependencies)
-	tar -czf $@ $<
+	tar -czf $@ autoortho_linux_$(SAFE_VERSION)
 
 bin: autoortho/.version
 	# Ensure required Linux libraries and helper binaries are executable before packaging


### PR DESCRIPTION
Fixes: #146

- Add Linux job matrix to Actions to run with two different distros
- Add Ubuntu code names to artifact file names to keep them separate