### PR TITLE
gui: Prevent focus by hovering mouse wheel

### DIFF
--- a/autoortho/config_ui_qt.py
+++ b/autoortho/config_ui_qt.py
@@ -1638,7 +1638,7 @@ class ConfigUI(QMainWindow):
                 old_level = logging.getLevelName(root_logger.level)
                 root_logger.setLevel(min_level)
                 level_name = logging.getLevelName(min_level)
-                log.info(f"Root logger adjusted: {old_level} → {level_name} (handlers: {', '.join(handler_levels)})")
+                log.info(f"Root logger adjusted: {old_level} -> {level_name} (handlers: {', '.join(handler_levels)})")
         except Exception as e:
             log.error(f"Failed to update root logger level: {e}")
 


### PR DESCRIPTION
    The contents of SpinBox and ComboBox widgets can sometimes be
    accidentally changed when using the mouse scroll wheel to scroll
    their containing layout widget.

    Fix this by ignoring wheel events in these widgets when they do not
    have focus.  They can still be changed after gaining explicit
    focus on them by clicking or tabbing.

    * ModernSpinBox:  Add wheelEvent handler to its class definition and
    change its FocusPolicy to exclude WheelFocus.
    * ComboBox: Add an eventFilter, install it on ComboBox widgets, and
    change its FocusPolicy to exclude WheelFocus.

Also fix an illegal char in a log message.