### PR TITLE
Handle invalid scenery zip files

### DIFF
--- a/autoortho/downloader.py
+++ b/autoortho/downloader.py
@@ -149,6 +149,9 @@ class Zip(object):
                 return
 
             for dir in zip_path.iterdir():
+                # Some zip files have a directory with this name.  Invalid and unexpected!
+                if dir.name == "*":
+                    continue
                 os.makedirs(os.path.join(destpath, dir.name), exist_ok=True)
                 for entry in (zip_path / dir.name).iterdir():
                     with (


### PR DESCRIPTION
Fixes: #332

Some zip files in the scenery GitHub have invalid ("*") directory names. The pre-2.0.4 version of the scenery installer was not affected by these because it did a full extraction of the zip file, which skips over invalid items.
The 2.0.4 version walks through the zip file and so needs to filter out these invalid items.  This commit adds that step to skip these invalid entries.