### PR TITLE
Fix mount worker launch when running from Python debugger

### DIFF
--- a/autoortho/process_supervisor.py
+++ b/autoortho/process_supervisor.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 
 DEFAULT_WORKER_STOP_TIMEOUT = 3.0
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 @dataclass
@@ -70,8 +71,10 @@ class AOProcessSupervisor:
 
         if _is_frozen():
             cmd = [sys.executable]
+            cwd = None
         else:
-            cmd = [sys.executable, "-m", "autoortho"]
+            cmd = [sys.executable, str(_REPO_ROOT / "autoortho")]
+            cwd = str(_REPO_ROOT)
 
         cmd += [
             "--root",
@@ -96,6 +99,8 @@ class AOProcessSupervisor:
             "stdout": std_file,
             "stderr": std_file,
         }
+        if cwd:
+            popen_kwargs["cwd"] = cwd
         if os.name == "nt":
             popen_kwargs["creationflags"] = (
                 getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
@@ -105,9 +110,10 @@ class AOProcessSupervisor:
             popen_kwargs["start_new_session"] = True
 
         log.debug(
-            "Launching mount worker: frozen=%s exe=%s cmd=%s",
+            "Launching mount worker: frozen=%s exe=%s cwd=%s cmd=%s",
             _is_frozen(),
             sys.executable,
+            cwd,
             cmd,
         )
         try:


### PR DESCRIPTION
## Summary

- Replaces `python -m autoortho` with an explicit path to the package directory and sets `cwd` explicitly in `Popen`
- Fixes "No module named autoortho" error in mount worker subprocesses when running under the VSCode Python debugger
- Confirmed working by @karlrado in #407

## Why

`python -m autoortho` relies on the subprocess inheriting a correct `sys.path`, which breaks under debugpy because the debugger's path manipulations are not propagated to child processes. Using an absolute path computed from `__file__` makes the worker launch reliable regardless of the parent process environment.