### PR TITLE
Fix coloured bands from partially composed mipmap images

### DIFF
--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -7426,11 +7426,11 @@ class Tile(object):
         startrow = mm_offset // bytes_per_chunk_row
         endrow = (mm_offset + max(0, length - 1)) // bytes_per_chunk_row
 
-        # Clamp to valid range of chunk rows for this mipmap
-        chunk_rows_in_mm = base_height_px // 256
-        if chunk_rows_in_mm == 0:
-            log.error(f"Chunk rows in mipmap {mipmap} is 0!  Base height: {base_height_px}  Mipmap: {mipmap}")
+        # A mipmap smaller than one chunk still occupies one row; 0 here made
+        # the clamps below produce -1, slicing chunks from the end of the tile.
+        chunk_rows_in_mm = max(1, base_height_px // 256)
 
+        # Clamp to valid range of chunk rows for this mipmap
         if startrow >= chunk_rows_in_mm:
             startrow = chunk_rows_in_mm - 1
         if endrow >= chunk_rows_in_mm:
@@ -7438,9 +7438,27 @@ class Tile(object):
         if endrow < startrow:
             endrow = startrow
 
+        # The rows above are in mipmap space, but get_img() composes at the zoom
+        # _get_quick_zoom() returns, which min_zoom can clamp upwards. Rescale so
+        # the range spans the image that will actually be built.
+        src_rows = chunk_rows_in_mm
+        try:
+            _, _, _, _src_h, _, _ = self._get_quick_zoom(
+                min(self.max_zoom - mipmap, self.max_zoom), self.min_zoom)
+            src_rows = max(1, int(_src_h))
+        except Exception:
+            src_rows = chunk_rows_in_mm
+
+        if src_rows > chunk_rows_in_mm and chunk_rows_in_mm > 0:
+            scale = src_rows / float(chunk_rows_in_mm)
+            startrow = int(startrow * scale)
+            endrow = min(src_rows - 1, int((endrow + 1) * scale) - 1)
+            if endrow < startrow:
+                endrow = startrow
+
         # Prefetch one extra chunk-row ahead to reduce subsequent stalls
-        if endrow < (chunk_rows_in_mm - 1):
-            endrow = min(endrow + 1, chunk_rows_in_mm - 1)
+        if endrow < (src_rows - 1):
+            endrow = min(endrow + 1, src_rows - 1)
 
         log.debug(f"Startrow: {startrow} Endrow: {endrow} bytes_per_chunk_row: {bytes_per_chunk_row} width_px: {base_width_px} height_px: {base_height_px}")
         
@@ -7463,6 +7481,13 @@ class Tile(object):
         # ═══════════════════════════════════════════════════════════════════
         # PYTHON FALLBACK PATH
         # ═══════════════════════════════════════════════════════════════════
+        # gen_mipmaps() only limits compression when given a non-zero
+        # compress_bytes; otherwise it compresses the whole composed image. A
+        # partially composed image would therefore store its unfilled rows as
+        # missing_color, so compose the whole thing.
+        if offset != 0:
+            startrow, endrow = 0, None
+
         # Pass the per-request budget to get_img (each read() gets its own budget)
         new_im = self.get_img(mipmap, startrow, endrow,
                 maxwait=self.get_maxwait(), time_budget=time_budget)

--- a/autoortho/test_getortho.py
+++ b/autoortho/test_getortho.py
@@ -2153,3 +2153,64 @@ class TestTerrainTileLookup:
         lookup.clear_cache()
         assert lookup._highzoom_count == 0
         assert len(lookup._highzoom_index) == 0
+
+def test_get_bytes_mid_mipmap_read_builds_a_complete_buffer(tmpdir):
+    """A read past the mipmap boundary must produce a complete mipmap buffer.
+
+    gen_mipmaps() compresses from row 0 over a height derived from
+    compress_bytes, and replaces the mipmap databuffer with the result. Two ways
+    to get this wrong, both ending in missing_color on screen:
+
+    - compose only some chunk rows and compress the whole image: the unfilled
+      rows are compressed in as missing_color;
+    - limit compression to the composed rows: the buffer is then shorter than
+      the mipmap, and DDS.read() pads the remainder with missing_color.
+
+    So for a read that is not at the mipmap boundary, the image must be composed
+    in full and compressed in full. Uses max_zoom=15 / min_zoom=14, where the
+    clamped zoom gives the composed image more chunk rows than the mipmap.
+    """
+    tile = getortho.Tile(2176, 3232, 'BI', 16, min_zoom=14, max_zoom=15,
+                         cache_dir=str(tmpdir))
+
+    calls = {}
+
+    class _Img:
+        size = (256, 256)
+
+        def close(self):
+            pass
+
+    def fake_get_img(mipmap, startrow=0, endrow=None, **kwargs):
+        calls['img'] = (mipmap, startrow, endrow)
+        return _Img()
+
+    def fake_gen_mipmaps(img, startmipmap=0, maxmipmaps=99, compress_bytes=0):
+        calls['compress_bytes'] = compress_bytes
+
+    tile.get_img = fake_get_img
+    tile.dds.gen_mipmaps = fake_gen_mipmaps
+
+    checked = 0
+    for mipmap in range(1, tile.max_mipmap + 1):
+        mm = tile.dds.mipmap_list[mipmap]
+        if mm.length <= 8192:
+            continue
+        calls.clear()
+        tile.get_bytes(mm.startpos + mm.length // 2, 4096)
+        if 'compress_bytes' not in calls:
+            continue
+        checked += 1
+        _, startrow, endrow = calls['img']
+
+        assert calls['compress_bytes'] == 0, (
+            f"mipmap {mipmap}: compression limited to "
+            f"{calls['compress_bytes']} bytes on a mid-mipmap read; the buffer "
+            f"would be shorter than the mipmap and read() would pad it with "
+            f"missing_color")
+        assert (startrow, endrow) == (0, None), (
+            f"mipmap {mipmap}: whole image is compressed but only rows "
+            f"{startrow}-{endrow} were composed; the rest would be stored as "
+            f"missing_color")
+
+    assert checked, "no mipmap exercised the mid-mipmap read path"


### PR DESCRIPTION
## Problem

Coloured bands appear across the terrain, using the configured `missing_color`.
They show up as horizontal strips spanning whole rows of tiles, get worse from
the second or third scene onward, and become obvious when zooming out. Once a
band appears it stays for the rest of the session.

Re-reading the affected tile through the mount always returns clean data, which
makes this look like a rendering issue rather than a texture one. It isn't:
X-Plane caches a texture the first time it reads it, so a tile served while
incomplete stays wrong on screen even though it rebuilds correctly afterwards.

<img width="988" height="522" alt="pr-mipmap-bands" src="https://github.com/user-attachments/assets/4d6e3f93-0717-421a-8ab0-02b5bf958aa3" />

*A 3x3 block of tiles, built from real cached chunks. Left: what `get_img()`
composes when the bug triggers — one chunk row in four per tile, the rest
`missing_color` (the default `[66, 77, 55]`). Because every tile loses the same
rows, the result reads as horizontal bands across the terrain. Right: the same
area after the fix.*

### In flight

<img width="1100" height="714" alt="pr-inflight-bands" src="https://github.com/user-attachments/assets/4e415833-0abc-46bc-9e00-7ca2a80ad41f" />

*LGAV, after loading a second scene. For this capture `missing_color` was set to
`[94, 11, 0]` (dark red) instead of the default `[66, 77, 55]`, to make the
affected areas obvious; the magenta tint is that red seen through X-Plane's
atmospheric haze. With the default colour the same bands read as dark patches
and are easy to mistake for terrain shading, which is likely why this has gone
unreported. The bands span whole rows of tiles and stop at the coastline
because only land tiles are textured.*

## Root cause

`get_bytes()` computes chunk row bounds from the mipmap's own size in the DDS:

```python
base_height_px   = int(self.dds.height) >> mipmap
chunk_rows_in_mm = base_height_px // 256
```

`get_img()` does not use that geometry. It composes its source image at the zoom
`_get_quick_zoom()` returns, and `min_zoom` can clamp that zoom upwards. With
`max_zoom=15` and `min_zoom=14`, mipmap 3 asks for ZL12, gets clamped to ZL14,
and the source image ends up with 4 chunk rows where the mipmap has 1. Passing
mipmap-space rows straight through then selects `chunks[0:4]` out of 16 — one
row in four. The other three keep `missing_color`.

That alone would be harmless if only the filled rows were compressed, but
`gen_mipmaps()` limits compression only when given a non-zero `compress_bytes`,
which `get_bytes()` sets solely for a read starting at the mipmap boundary. Any
other read compresses the whole image and replaces the mipmap buffer, storing
the untouched rows as `missing_color`.

A second issue in the same block: a mipmap smaller than one chunk gives
`chunk_rows_in_mm == 0`, so the clamps below produce `startrow = endrow = -1`
and `get_img()` evaluates `chunks[-n:]` — the last chunks of the tile instead of
the first. The condition was already detected and logged as an error without
being handled. It is reachable in normal use: mipmap 4 of a 2048x2048 tile is
128px.

## Fix

- Map the row range onto the geometry `get_img()` actually composes, so a
  clamped zoom no longer leaves rows outside the requested range.
- Compose the whole image for reads that are not at the mipmap boundary, so a
  partially composed image is never compressed in full.
- Treat a sub-chunk mipmap as one chunk row.

Limiting compression to the composed rows instead, rather than composing the
whole image, does not work: the resulting buffer is shorter than the mipmap and
`DDS.read()` pads the remainder with `missing_color`, which puts the bands back
in a thinner form. The regression test covers both failure modes.

## Scope

Not specific to one setting. Sweeping every `tile_zoom` x `max_zoom` x
`min_zoom` combination `Tile()` accepts, and reading at several offsets within
each mipmap:

| | clean combinations |
|---|---|
| before | 0 / 43 |
| after | 43 / 43 |

### Chunk requests

Composing the whole image requests more chunks than before, but no more than
the mipmaps need. Walking the whole file and counting unique chunks requested:

| config | before | after | needed by the mipmaps |
|---|---|---|---|
| `max_zoom=15 min_zoom=14` | 76 | 80 | 80 |
| `max_zoom=16 min_zoom=12` | 205 | 341 | 341 |
| `max_zoom=18 min_zoom=16` | 200 | 336 | 336 |

The last column is the number of chunks the five mipmaps require at their
native zoom levels. The previous behaviour requested fewer chunks because it
composed only part of each image and stored the remainder as `missing_color`,
so the two are not equivalent work.

## Testing

- `test_get_bytes_mid_mipmap_read_builds_a_complete_buffer` added; it fails on
  the current code and passes with the fix. It covers both ways of getting this
  wrong: compressing rows that were never composed, and limiting compression so
  the buffer ends up shorter than the mipmap.
- Full CI suite (`test_getortho.py`, `test_pydds.py`, `test_downloader.py`):
  119 passed.
- Verified in flight on macOS: instrumenting every write to `MipMap.databuffer`
  recorded 285 of 301 events storing mipmap 3 at exactly 75.0% `missing_color`
  through `gen_mipmaps <- get_bytes <- _read_dds_bytes_inner`. After the fix the
  same instrumentation records zero over 12000 reads, and the bands are gone.
